### PR TITLE
Ajout d'un champs 'verify_peer' à la ligne 44 dans le

### DIFF
--- a/src/ETNA/Silex/Provider/RabbitMQ/RabbitMQServiceProvider.php
+++ b/src/ETNA/Silex/Provider/RabbitMQ/RabbitMQServiceProvider.php
@@ -42,7 +42,6 @@ class RabbitMQServiceProvider implements ServiceProviderInterface
                                 $options["password"],
                                 $options["vhost"],
                                 [ 'verify_peer' => false ]
-
                             ];
 
                             $reflection = new \ReflectionClass($amqp_class);


### PR DESCRIPTION
RabbitMQServiceProvider.php pour que la connexion ssl via le port 5671
fonctionne.
