### PR TITLE
[FIX#36025] Suppression de la gestion du timeout coté connection rabbitmq

### DIFF
--- a/src/RabbitMQServiceProvider.php
+++ b/src/RabbitMQServiceProvider.php
@@ -46,11 +46,6 @@ class RabbitMQServiceProvider implements ServiceProviderInterface
                                 $amqp_class = 'PhpAmqpLib\Connection\AMQPConnection';
                             }
 
-                            $amqp_args[] = [
-                                'read_write_timeout' => 60,
-                                'heartbeat'          => 30
-                            ];
-
                             $reflection = new \ReflectionClass($amqp_class);
                             $connection = $reflection->newInstanceArgs($amqp_args);
 


### PR DESCRIPTION
On fait désormais confiance au HAProxy pour gérer les timeout